### PR TITLE
Fix engine logic

### DIFF
--- a/server/src/api.ts
+++ b/server/src/api.ts
@@ -9,6 +9,7 @@ import {
     refillVehicle,
     setVehicleConsumptionRates,
     toggleEngine,
+    toggleEngineWithoutPlayer,
 } from './functions.js';
 import { FUEL_TYPES } from './config.js';
 import { useRebar } from '@Server/index.js';
@@ -44,6 +45,10 @@ function useFuelAPI() {
         toggleEngine(player);
     }
 
+    function toggleVehicleEngineWithoutPlayer(vehicle: alt.Vehicle) {
+        toggleEngineWithoutPlayer(vehicle);
+    }
+
     async function getFuelType(vehicle: alt.Vehicle) {
         await getVehicleFuelType(vehicle);
     }
@@ -72,6 +77,7 @@ function useFuelAPI() {
         createAscendedFuelPropertie,
         setConsumptionRates,
         toggleVehicleEngine,
+        toggleVehicleEngineWithoutPlayer,
         getFuelType,
         getFuelConsumption,
         refill,

--- a/server/src/functions.ts
+++ b/server/src/functions.ts
@@ -68,11 +68,7 @@ export async function updateFuelConsumption(player: alt.Player): Promise<void> {
     const currentPos = vehicle.pos;
     const currentTime = Date.now();
 
-    const distance = Math.sqrt(
-        Math.pow(currentPos.x - initialPos.x, 2) +
-            Math.pow(currentPos.y - initialPos.y, 2) +
-            Math.pow(currentPos.z - initialPos.z, 2),
-    );
+    const distance = Rebar.utility.vector.distance(currentPos, initialPos);
 
     const timeElapsed = (currentTime - initialTime) / 1000;
     if (timeElapsed <= 0) {


### PR DESCRIPTION
This fixes the logic error that would prevent the engine from toggeling off due to wrong fuel or no fuel if the driver is not an owner of the vehicle

additionally exposes the new toggleEngineWithoutPlayer through the api